### PR TITLE
Auth - Please Read

### DIFF
--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -27,7 +27,7 @@ def authenticate():
     """
     if current_user.is_authenticated:
         return current_user.to_dict()
-    return {'errors': ['Unauthorized']}, 401
+    return {'errors': ['Unauthorized']}
 
 # Log In
 

--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -46,7 +46,7 @@ def login():
         user = User.query.filter(User.email == form.data['email']).first()
         login_user(user)
         return user.to_dict()
-    return {'errors': validation_errors_to_error_messages(form.errors)}, 401
+    return {'errors': validation_errors_to_error_messages(form.errors)}
 
 # Log Out
 
@@ -91,4 +91,4 @@ def unauthorized():
     """
     Returns unauthorized JSON when flask-login authentication fails
     """
-    return {'errors': ['Unauthorized']}, 401
+    return {'errors': ['Unauthorized']}

--- a/react-app/src/components/Dropdown/index.js
+++ b/react-app/src/components/Dropdown/index.js
@@ -50,7 +50,7 @@ const Dropdown = ({ setAuthenticated }) => {
 								Demo Events
 							</NavLink>
 						</li>
-						<li classname="nav-item">
+						<li className="nav-item">
 							<LogoutButton setAuthenticated={setAuthenticated} />
 						</li>
 					</ul>

--- a/react-app/src/components/auth/LoginForm.js
+++ b/react-app/src/components/auth/LoginForm.js
@@ -32,8 +32,8 @@ const LoginForm = ({ authenticated, setAuthenticated }) => {
   return (
     <form onSubmit={onLogin}>
       <div>
-        {errors.map((error) => (
-          <div>{error}</div>
+        {errors.map((error, index) => (
+          <div key={index}>{error}</div>
         ))}
       </div>
       <div>


### PR DESCRIPTION
So I took out the "401"s that we were sending back from the server in the /api/auth/ routes. They seemed unnecessary to me outside of development. All we need are the errors to be sent. This removes them from appearing in the console, while still keeping the functionality the same. I'm welcome for at least 2 of yall to review this and let me know if they think this is an appropriate way to handle the issue please. The only issue I can think of is if somebody wanted to check the Network tab in their browser devtools then it'd appear as a "200" instead of a "401", but again it still functions the way we want it.
